### PR TITLE
fix(devex): Service container needs to depend on Postgres health

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,7 @@
+version: '3'
+
 services:
-  service:
+  api:
     build:
       context: .
       dockerfile: dev.dockerfile
@@ -15,6 +17,10 @@ services:
       - 10502:10502
     volumes:
       - ./:/app
+    depends_on:
+      db:
+        condition: service_healthy
+
   db:
     image: postgres:15.1-alpine
     environment:


### PR DESCRIPTION
## Changed

- "service" container is now called "api"
- Added depends_on block for API container to wait for Postgres healthcheck

Signed-off-by: Tim O'Guin <timoguin@gmail.com>
