### PR TITLE
Allow exchanging of API Keys for JWTs

### DIFF
--- a/database/create_tables.sql
+++ b/database/create_tables.sql
@@ -62,7 +62,7 @@ CREATE TABLE IF NOT EXISTS app_user(
 -- -----------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS api_key(
     api_key_id UUID PRIMARY KEY,
-    secret_hash BYTEA,
+    secret_hash TEXT,
     app_info_id BIGINT REFERENCES app_info(app_info_id),
     created_utc TIMESTAMP WITH TIME ZONE NOT NULL
 );

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/main/java/com/mytiki/l0_auth/features/latest/api_key/ApiKeyAO.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/api_key/ApiKeyAO.java
@@ -9,7 +9,6 @@ import java.time.ZonedDateTime;
 
 public class ApiKeyAO {
     private String id;
-    private String secret;
     private ZonedDateTime created;
 
     public String getId() {
@@ -18,14 +17,6 @@ public class ApiKeyAO {
 
     public void setId(String id) {
         this.id = id;
-    }
-
-    public String getSecret() {
-        return secret;
-    }
-
-    public void setSecret(String secret) {
-        this.secret = secret;
     }
 
     public ZonedDateTime getCreated() {

--- a/src/main/java/com/mytiki/l0_auth/features/latest/api_key/ApiKeyAOCreate.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/api_key/ApiKeyAOCreate.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_auth.features.latest.api_key;
+
+public class ApiKeyAOCreate extends ApiKeyAO {
+    private String secret;
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+}

--- a/src/main/java/com/mytiki/l0_auth/features/latest/api_key/ApiKeyConfig.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/api_key/ApiKeyConfig.java
@@ -6,12 +6,18 @@
 package com.mytiki.l0_auth.features.latest.api_key;
 
 import com.mytiki.l0_auth.features.latest.app_info.AppInfoService;
+import com.mytiki.l0_auth.features.latest.refresh.RefreshService;
 import com.mytiki.l0_auth.features.latest.user_info.UserInfoService;
+import com.mytiki.l0_auth.security.OauthScopes;
 import com.mytiki.l0_auth.utilities.Constants;
+import com.nimbusds.jose.JWSSigner;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+import java.util.List;
 
 @EnableJpaRepositories(ApiKeyConfig.PACKAGE_PATH)
 @EntityScan(ApiKeyConfig.PACKAGE_PATH)
@@ -27,7 +33,12 @@ public class ApiKeyConfig {
     public ApiKeyService apiKeyService(
             @Autowired ApiKeyRepository repository,
             @Autowired UserInfoService userInfoService,
-            @Autowired AppInfoService appInfoService){
-        return new ApiKeyService(repository, userInfoService, appInfoService);
+            @Autowired AppInfoService appInfoService,
+            @Autowired RefreshService refreshService,
+            @Autowired JWSSigner signer,
+            @Autowired OauthScopes allowedScopes,
+            @Value("${com.mytiki.l0_auth.oauth.client_credentials.public_scopes}") List<String> publicScopes){
+        return new ApiKeyService(repository, userInfoService, appInfoService, refreshService, signer,
+                allowedScopes, publicScopes);
     }
 }

--- a/src/main/java/com/mytiki/l0_auth/features/latest/api_key/ApiKeyConfig.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/api_key/ApiKeyConfig.java
@@ -30,5 +30,4 @@ public class ApiKeyConfig {
             @Autowired AppInfoService appInfoService){
         return new ApiKeyService(repository, userInfoService, appInfoService);
     }
-
 }

--- a/src/main/java/com/mytiki/l0_auth/features/latest/api_key/ApiKeyController.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/api_key/ApiKeyController.java
@@ -7,10 +7,7 @@ package com.mytiki.l0_auth.features.latest.api_key;
 
 import com.mytiki.spring_rest_api.ApiConstants;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 import java.util.List;
@@ -34,8 +31,11 @@ public class ApiKeyController {
     }
 
     @RequestMapping(method = RequestMethod.POST, path = PATH_APP_KEY)
-    public ApiKeyAO createAppKey(Principal principal, @PathVariable String appId) {
-        return service.create(principal.getName(), appId);
+    public ApiKeyAOCreate createAppKey(
+            Principal principal,
+            @PathVariable String appId,
+            @RequestParam(required = false) boolean isPublic) {
+        return service.create(principal.getName(), appId, isPublic);
     }
 
     @RequestMapping(method = RequestMethod.DELETE, path = PATH_KEY)

--- a/src/main/java/com/mytiki/l0_auth/features/latest/api_key/ApiKeyController.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/api_key/ApiKeyController.java
@@ -5,8 +5,15 @@
 
 package com.mytiki.l0_auth.features.latest.api_key;
 
+import com.mytiki.l0_auth.utilities.Constants;
 import com.mytiki.spring_rest_api.ApiConstants;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
@@ -41,5 +48,20 @@ public class ApiKeyController {
     @RequestMapping(method = RequestMethod.DELETE, path = PATH_KEY)
     public void revoke(Principal principal, @PathVariable String keyId) {
         service.revoke(principal.getName(), keyId);
+    }
+
+    @RequestMapping(
+            method = RequestMethod.POST,
+            path = Constants.OAUTH_TOKEN_PATH,
+            consumes = {MediaType.APPLICATION_FORM_URLENCODED_VALUE},
+            params = {"client_id", "client_secret"})
+    public OAuth2AccessTokenResponse grant(
+            @RequestParam(name = "grant_type") AuthorizationGrantType grantType,
+            @RequestParam(required = false) String scope,
+            @RequestParam(name = "client_id") String clientId,
+            @RequestParam(name = "client_secret") String clientSecret) {
+        if (!grantType.equals(AuthorizationGrantType.CLIENT_CREDENTIALS))
+            throw new OAuth2AuthorizationException(new OAuth2Error(OAuth2ErrorCodes.UNSUPPORTED_GRANT_TYPE));
+        return service.authorize(clientId, clientSecret, scope);
     }
 }

--- a/src/main/java/com/mytiki/l0_auth/features/latest/api_key/ApiKeyDO.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/api_key/ApiKeyDO.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 @Table(name = "api_key")
 public class ApiKeyDO implements Serializable {
     private UUID id;
-    private byte[] hashedSecret;
+    private String hashedSecret;
     private AppInfoDO app;
     private ZonedDateTime created;
 
@@ -31,11 +31,11 @@ public class ApiKeyDO implements Serializable {
     }
 
     @Column(name = "secret_hash")
-    public byte[] getHashedSecret() {
+    public String getHashedSecret() {
         return hashedSecret;
     }
 
-    public void setHashedSecret(byte[] hashedSecret) {
+    public void setHashedSecret(String hashedSecret) {
         this.hashedSecret = hashedSecret;
     }
 

--- a/src/main/java/com/mytiki/l0_auth/features/latest/api_key/ApiKeyService.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/api_key/ApiKeyService.java
@@ -7,35 +7,57 @@ package com.mytiki.l0_auth.features.latest.api_key;
 
 import com.mytiki.l0_auth.features.latest.app_info.AppInfoDO;
 import com.mytiki.l0_auth.features.latest.app_info.AppInfoService;
+import com.mytiki.l0_auth.features.latest.refresh.RefreshService;
 import com.mytiki.l0_auth.features.latest.user_info.UserInfoAO;
 import com.mytiki.l0_auth.features.latest.user_info.UserInfoService;
+import com.mytiki.l0_auth.security.JWSBuilder;
+import com.mytiki.l0_auth.security.OauthScope;
+import com.mytiki.l0_auth.security.OauthScopes;
+import com.mytiki.l0_auth.utilities.Constants;
 import com.mytiki.spring_rest_api.ApiExceptionBuilder;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSObject;
+import com.nimbusds.jose.JWSSigner;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
 import java.time.ZonedDateTime;
-import java.util.Base64;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 public class ApiKeyService {
     private final ApiKeyRepository repository;
     private final UserInfoService userInfoService;
     private final AppInfoService appInfoService;
+    private final RefreshService refreshService;
+    private final JWSSigner signer;
     private final PasswordEncoder secretEncoder;
+    private final OauthScopes allowedScopes;
+    private final List<String> publicScopes;
 
     public ApiKeyService(
             ApiKeyRepository repository,
             UserInfoService userInfoService,
-            AppInfoService appInfoService) {
+            AppInfoService appInfoService,
+            RefreshService refreshService,
+            JWSSigner signer,
+            OauthScopes allowedScopes,
+            List<String> publicScopes) {
         this.repository = repository;
         this.userInfoService = userInfoService;
         this.appInfoService = appInfoService;
+        this.refreshService = refreshService;
+        this.signer = signer;
         this.secretEncoder = new BCryptPasswordEncoder(12);
+        this.allowedScopes = allowedScopes;
+        this.publicScopes = publicScopes;
     }
 
     public ApiKeyAOCreate create(String userId, String appId, boolean isPublic){
@@ -84,6 +106,54 @@ public class ApiKeyService {
         if(found.isPresent()){
             guardAppUser(userId, found.get().getApp().getAppId().toString());
             repository.delete(found.get());
+        }
+    }
+
+    public OAuth2AccessTokenResponse authorize(String clientId, String clientSecret, String requestScopes){
+        Optional<ApiKeyDO> found = repository.findById(UUID.fromString(clientId));
+        if (found.isEmpty())
+            throw new OAuth2AuthorizationException(new OAuth2Error(
+                    OAuth2ErrorCodes.ACCESS_DENIED,
+                    "client_id and/or client_secret are invalid",
+                    null
+            ));
+        try {
+            Map<String, OauthScope> scopes = allowedScopes.parse(requestScopes);
+            if(found.get().getHashedSecret() == null && clientSecret == null){
+                scopes = allowedScopes.filter(scopes, publicScopes);
+            }else{
+                if(!secretEncoder.matches(clientSecret, found.get().getHashedSecret())){
+                    throw new OAuth2AuthorizationException(new OAuth2Error(
+                            OAuth2ErrorCodes.ACCESS_DENIED),
+                            "client_id and/or client_secret are invalid");
+                }
+            }
+            String subject = null;
+            AppInfoDO app = found.get().getApp();
+            if(app != null)
+                subject = app.getAppId().toString();
+
+            List<String>[] audAndScp = allowedScopes.getAudAndScp(scopes);
+            JWSObject token = new JWSBuilder()
+                    .expIn(Constants.TOKEN_EXPIRY_DURATION_SECONDS)
+                    .sub(subject)
+                    .aud(audAndScp[0])
+                    .scp(audAndScp[1])
+                    .build(signer);
+
+            return OAuth2AccessTokenResponse
+                    .withToken(token.serialize())
+                    .tokenType(OAuth2AccessToken.TokenType.BEARER)
+                    .expiresIn(Constants.TOKEN_EXPIRY_DURATION_SECONDS)
+                    .scopes(scopes.keySet())
+                    .refreshToken(refreshService.issue(subject, audAndScp[0], audAndScp[1]))
+                    .build();
+        } catch (JOSEException e) {
+            throw new OAuth2AuthorizationException(new OAuth2Error(
+                    OAuth2ErrorCodes.SERVER_ERROR,
+                    "Issue with JWT construction",
+                    null
+            ), e);
         }
     }
 

--- a/src/main/java/com/mytiki/l0_auth/features/latest/otp/OtpConfig.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/otp/OtpConfig.java
@@ -7,15 +7,19 @@ package com.mytiki.l0_auth.features.latest.otp;
 
 import com.mytiki.l0_auth.features.latest.refresh.RefreshService;
 import com.mytiki.l0_auth.features.latest.user_info.UserInfoService;
+import com.mytiki.l0_auth.security.OauthScopes;
 import com.mytiki.l0_auth.utilities.Constants;
 import com.mytiki.l0_auth.utilities.Mustache;
 import com.mytiki.l0_auth.utilities.Sendgrid;
 import com.nimbusds.jose.JWSSigner;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+import java.util.List;
 
 @EnableJpaRepositories(OtpConfig.PACKAGE_PATH)
 @EntityScan(OtpConfig.PACKAGE_PATH)
@@ -32,8 +36,11 @@ public class OtpConfig {
             @Autowired Sendgrid sendgrid,
             @Autowired JWSSigner jwsSigner,
             @Autowired RefreshService refreshService,
-            @Autowired UserInfoService userInfoService) {
-        return new OtpService(otpRepository, templates, sendgrid, jwsSigner, refreshService, userInfoService);
+            @Autowired UserInfoService userInfoService,
+            @Autowired OauthScopes allowedScopes,
+            @Value("${com.mytiki.l0_auth.oauth.password.anonymous_scopes}") List<String> anonymousScopes) {
+        return new OtpService(otpRepository, templates, sendgrid, jwsSigner, refreshService, userInfoService,
+                allowedScopes, anonymousScopes);
     }
 
     @Bean

--- a/src/main/java/com/mytiki/l0_auth/features/latest/otp/OtpController.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/otp/OtpController.java
@@ -19,8 +19,6 @@ import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @Tag(name = "AUTH")
 @RestController
 @RequestMapping(value = ApiConstants.API_LATEST_ROUTE)
@@ -50,14 +48,13 @@ public class OtpController {
     public OAuth2AccessTokenResponse grant(
             @Parameter(
                     schema = @Schema(type = "string"),
-                    description = "(password, refresh_token, urn:ietf:params:oauth:grant-type:jwt-bearer)")
+                    description = "(password, refresh_token, client_credentials)") //, urn:ietf:params:oauth:grant-type:jwt-bearer
             @RequestParam(name = "grant_type") AuthorizationGrantType grantType,
             @RequestParam(required = false) String scope,
             @RequestParam(name = "username") String deviceId,
-            @RequestParam(name = "password") String code,
-            @RequestParam(required = false) List<String> audience) {
+            @RequestParam(name = "password") String code) {
         if (!grantType.equals(AuthorizationGrantType.PASSWORD))
             throw new OAuth2AuthorizationException(new OAuth2Error(OAuth2ErrorCodes.UNSUPPORTED_GRANT_TYPE));
-        return service.authorize(deviceId, code, audience);
+        return service.authorize(deviceId, code, scope);
     }
 }

--- a/src/main/java/com/mytiki/l0_auth/features/latest/user_info/UserInfoAO.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/user_info/UserInfoAO.java
@@ -9,19 +9,18 @@ import java.time.ZonedDateTime;
 import java.util.Set;
 
 public class UserInfoAO {
-    private String sub;
     private String userId;
     private String email;
     private ZonedDateTime modified;
     private ZonedDateTime created;
     private Set<String> apps;
 
-    public String getSub() {
-        return sub;
+    public String getUserId() {
+        return userId;
     }
 
-    public void setSub(String sub) {
-        this.sub = sub;
+    public void setUserId(String userId) {
+        this.userId = userId;
     }
 
     public String getEmail() {
@@ -30,14 +29,6 @@ public class UserInfoAO {
 
     public void setEmail(String email) {
         this.email = email;
-    }
-
-    public String getUserId() {
-        return userId;
-    }
-
-    public void setUserId(String userId) {
-        this.userId = userId;
     }
 
     public ZonedDateTime getModified() {

--- a/src/main/java/com/mytiki/l0_auth/features/latest/user_info/UserInfoController.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/user_info/UserInfoController.java
@@ -17,11 +17,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
-
+@Tag(name = "ACCOUNT")
 @RestController
 @RequestMapping(value = ApiConstants.API_LATEST_ROUTE)
 public class UserInfoController {
-    public static final String PATH_USER = "user/{userId}";
+    public static final String PATH_USER = "user";
 
     private final UserInfoService service;
 
@@ -29,12 +29,11 @@ public class UserInfoController {
         this.service = service;
     }
 
-    @Tag(name = "ACCOUNT")
     @Operation(operationId = Constants.PROJECT_DASH_PATH +  "-user-post",
             summary = "Update a User",
             description = "Update the authorized user's profile",
             security = @SecurityRequirement(name = "jwt"))
-    @RequestMapping(method = RequestMethod.POST, path = PATH_USER)
+    @RequestMapping(method = RequestMethod.POST, path = PATH_USER + "/{userId}")
     public UserInfoAO update(
             Principal principal,
             @PathVariable String userId,
@@ -50,12 +49,11 @@ public class UserInfoController {
         return service.update(userId, body);
     }
 
-    @Tag(name = "AUTH")
-    @Operation(operationId = Constants.PROJECT_DASH_PATH +  "-oauth-userinfo-get",
+    @Operation(operationId = Constants.PROJECT_DASH_PATH +  "-user-get",
             summary = "Get User",
             description = "Get the authorized user's profile",
             security = @SecurityRequirement(name = "jwt"))
-    @RequestMapping(method = RequestMethod.GET, path = Constants.OAUTH_USERINFO_PATH)
+    @RequestMapping(method = RequestMethod.GET, path = PATH_USER )
     public UserInfoAO userinfo(Principal principal) {
         if(principal == null || principal.getName() == null)
             throw new ApiException(HttpStatus.FORBIDDEN);

--- a/src/main/java/com/mytiki/l0_auth/features/latest/user_info/UserInfoService.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/user_info/UserInfoService.java
@@ -25,7 +25,6 @@ public class UserInfoService {
         Optional<UserInfoDO> found = repository.findByUserId(UUID.fromString(userId));
         return found.map(this::toAO).orElseGet(() -> {
             UserInfoAO rsp = new UserInfoAO();
-            rsp.setSub(userId);
             rsp.setUserId(userId);
             return rsp;
         });
@@ -64,7 +63,6 @@ public class UserInfoService {
 
     private UserInfoAO toAO(UserInfoDO src){
         UserInfoAO rsp = new UserInfoAO();
-        rsp.setSub(src.getUserId().toString());
         rsp.setUserId(src.getUserId().toString());
         rsp.setEmail(src.getEmail());
         rsp.setCreated(src.getCreated());

--- a/src/main/java/com/mytiki/l0_auth/main/AppConfig.java
+++ b/src/main/java/com/mytiki/l0_auth/main/AppConfig.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.models.servers.Server;
 import jakarta.annotation.PostConstruct;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
@@ -33,6 +34,7 @@ import java.util.TimeZone;
         UtilitiesConfig.class,
         FeaturesConfig.class
 })
+@EnableConfigurationProperties
 public class AppConfig {
     @PostConstruct
     void starter() {

--- a/src/main/java/com/mytiki/l0_auth/security/JWSBuilder.java
+++ b/src/main/java/com/mytiki/l0_auth/security/JWSBuilder.java
@@ -3,8 +3,9 @@
  * MIT license. See LICENSE file in root directory.
  */
 
-package com.mytiki.l0_auth.utilities;
+package com.mytiki.l0_auth.security;
 
+import com.mytiki.l0_auth.utilities.Constants;
 import com.nimbusds.jose.*;
 import com.nimbusds.jwt.JWTClaimsSet;
 
@@ -20,6 +21,7 @@ public class JWSBuilder {
     private ZonedDateTime exp;
     private Long expIn;
     private ZonedDateTime iat;
+    private List<String> scp;
 
     public JWSBuilder iat(ZonedDateTime instant){
         this.iat = instant;
@@ -46,8 +48,15 @@ public class JWSBuilder {
         return this;
     }
 
+    public JWSBuilder scp(List<String> scp){
+        if(scp != null && !scp.isEmpty())
+            this.scp = scp;
+        return this;
+    }
+
     public JWSBuilder aud(List<String> audiences){
-        this.aud = audiences;
+        if(audiences != null && !audiences.isEmpty())
+            this.aud = audiences;
         return this;
     }
 
@@ -68,6 +77,7 @@ public class JWSBuilder {
                                 .subject(sub)
                                 .audience(aud)
                                 .jwtID(jti)
+                                .claim("scp", scp)
                                 .build()
                                 .toJSONObject()
                 ));

--- a/src/main/java/com/mytiki/l0_auth/security/OauthConfig.java
+++ b/src/main/java/com/mytiki/l0_auth/security/OauthConfig.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,11 +24,23 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import java.lang.invoke.MethodHandles;
+import java.util.List;
 
 @Order(value = Integer.MIN_VALUE)
+@Import(OauthScopes.class)
 @ControllerAdvice
 public class OauthConfig {
     protected static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private List<OauthScope> scopes;
+
+    @Bean
+    public List<OauthScope> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(List<OauthScope> scopes) {
+        this.scopes = scopes;
+    }
 
     @Bean
     public HttpMessageConverter<OAuth2AccessTokenResponse> oAuth2AccessTokenResponseHttpMessageConverter() {

--- a/src/main/java/com/mytiki/l0_auth/security/OauthScope.java
+++ b/src/main/java/com/mytiki/l0_auth/security/OauthScope.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_auth.security;
+
+import java.util.List;
+
+public class OauthScope {
+    private List<String> aud;
+    private List<String> scp;
+
+    public List<String> getAud() {
+        return aud;
+    }
+
+    public void setAud(List<String> aud) {
+        this.aud = aud;
+    }
+
+    public List<String> getScp() {
+        return scp;
+    }
+
+    public void setScp(List<String> scp) {
+        this.scp = scp;
+    }
+}

--- a/src/main/java/com/mytiki/l0_auth/security/OauthScopes.java
+++ b/src/main/java/com/mytiki/l0_auth/security/OauthScopes.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_auth.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Configuration
+@ConfigurationProperties(value = "com.mytiki.l0-auth.oauth")
+public class OauthScopes {
+    private Map<String,OauthScope> scopes;
+
+    public Map<String, OauthScope> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(Map<String, OauthScope> scopes) {
+        this.scopes = scopes;
+    }
+
+    public Map<String, OauthScope> parse(String req){
+        return req == null ?
+                new HashMap<>() :
+                Arrays.stream(req.split(" "))
+                        .filter(scopes::containsKey)
+                        .collect(Collectors.toMap(e -> e, scopes::get));
+    }
+
+    public Map<String, OauthScope> filter(Map<String, OauthScope> scopes, List<String> criteria){
+        return scopes.entrySet()
+                .stream()
+                .filter(entry -> criteria.contains(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public List<String>[] getAudAndScp(Map<String, OauthScope> scopes){
+        Set<String> aud = new HashSet<>();
+        Set<String> scp = new HashSet<>();
+        scopes.values().forEach(scope -> {
+            if(scope.getAud() != null)
+                aud.addAll(scope.getAud());
+            if(scope.getScp() != null)
+                scp.addAll(scope.getScp());
+        });
+        List<String>[] rsp = new List[2];
+        rsp[0] = aud.stream().toList();
+        rsp[1] = scp.stream().toList();
+        return rsp;
+    }
+}

--- a/src/main/java/com/mytiki/l0_auth/utilities/Constants.java
+++ b/src/main/java/com/mytiki/l0_auth/utilities/Constants.java
@@ -25,5 +25,4 @@ public interface Constants {
     String OAUTH_PATH = "oauth";
     String OAUTH_TOKEN_PATH = OAUTH_PATH + "/token";
     String OAUTH_REVOKE_PATH = OAUTH_PATH + "/revoke";
-    String OAUTH_USERINFO_PATH = OAUTH_PATH + "/userinfo";
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,3 +30,10 @@ springdoc.api-docs.enabled=false
 springdoc.default-produces-media-type=application/json
 springdoc.default-consumes-media-type=application/json
 springdoc.version=@project.version@
+
+# OAUTH
+com.mytiki.l0_auth.oauth.scopes.index.aud=index.l0.mytiki.com
+com.mytiki.l0_auth.oauth.scopes.storage.aud=storage.l0.mytiki.com
+com.mytiki.l0_auth.oauth.scopes.auth.aud=auth.l0.mytiki.com
+com.mytiki.l0_auth.oauth.client_credentials.public_scopes=storage,index
+com.mytiki.l0_auth.oauth.password.anonymous_scopes=

--- a/src/test/java/com/mytiki/l0_auth/RefreshTest.java
+++ b/src/test/java/com/mytiki/l0_auth/RefreshTest.java
@@ -59,7 +59,7 @@ public class RefreshTest {
 
     @Test
     public void Test_Token_Success() throws JOSEException {
-        String token = service.issue(null, null);
+        String token = service.issue(null, null, null);
         assertNotNull(token);
 
         Jwt jwt = jwtDecoder.decode(token);
@@ -72,7 +72,7 @@ public class RefreshTest {
 
     @Test
     public void Test_Revoke_Success() throws JOSEException, ParseException {
-        String token = service.issue(null, null);
+        String token = service.issue(null, null, null);
         service.revoke(token);
 
         Jwt jwt = jwtDecoder.decode(token);
@@ -82,7 +82,7 @@ public class RefreshTest {
 
     @Test
     public void Test_Revoke_Replay_Success() throws JOSEException, ParseException {
-        String token = service.issue(null, null);
+        String token = service.issue(null, null, null);
         service.revoke(token);
         service.revoke(token);
 
@@ -93,7 +93,7 @@ public class RefreshTest {
 
     @Test
     public void Test_Authorize_Success() throws JOSEException, ParseException {
-        String token = service.issue(null, null);
+        String token = service.issue(null, null, null);
 
         OAuth2AccessTokenResponse rsp = service.authorize(token);
         assertNotNull(rsp.getAccessToken().getTokenValue());
@@ -110,7 +110,7 @@ public class RefreshTest {
 
     @Test
     public void Test_Authorize_Revoked_Success() throws JOSEException {
-        String token = service.issue(null, null);
+        String token = service.issue(null, null, null);
         service.revoke(token);
 
         OAuth2AuthorizationException ex = assertThrows(OAuth2AuthorizationException.class,
@@ -143,9 +143,9 @@ public class RefreshTest {
     }
 
     @Test
-    public void Test_Authorize_Audience_Success() throws JOSEException, ParseException {
+    public void Test_Authorize_Audience_Success() throws JOSEException {
         String audience = "storage.l0.mytiki.com";
-        String token = service.issue(null, List.of(audience));
+        String token = service.issue(null, List.of(audience), null);
 
         OAuth2AccessTokenResponse rsp = service.authorize(token);
         Jwt jwt = jwtDecoder.decode(rsp.getAccessToken().getTokenValue());
@@ -153,12 +153,23 @@ public class RefreshTest {
     }
 
     @Test
-    public void Test_Authorize_Subject_Success() throws JOSEException, ParseException {
+    public void Test_Authorize_Subject_Success() throws JOSEException {
         String subject = UUID.randomUUID().toString();
-        String token = service.issue(subject, null);
+        String token = service.issue(subject, null, null);
 
         OAuth2AccessTokenResponse rsp = service.authorize(token);
         Jwt jwt = jwtDecoder.decode(rsp.getAccessToken().getTokenValue());
         assertEquals(subject, jwt.getSubject());
+    }
+
+    @Test
+    public void Test_Authorize_Scope_Success() throws JOSEException {
+        String scp = "testScope";
+        String token = service.issue(null, null, List.of(scp));
+
+        OAuth2AccessTokenResponse rsp = service.authorize(token);
+        Jwt jwt = jwtDecoder.decode(rsp.getAccessToken().getTokenValue());
+        List<String> claim = jwt.getClaim("scp");
+        assertTrue(claim.contains(scp));
     }
 }

--- a/src/test/java/com/mytiki/l0_auth/UserInfoTest.java
+++ b/src/test/java/com/mytiki/l0_auth/UserInfoTest.java
@@ -49,7 +49,6 @@ public class UserInfoTest {
         assertEquals(saved.getModified().withNano(0), user.getModified().withNano(0));
         assertEquals(saved.getCreated().withNano(0), user.getCreated().withNano(0));
         assertEquals(0, user.getApps().size());
-        assertEquals(saved.getUserId().toString(), user.getSub());
         assertEquals(saved.getUserId().toString(), user.getUserId());
     }
 
@@ -61,7 +60,6 @@ public class UserInfoTest {
         assertNull(user.getModified());
         assertNull(user.getCreated());
         assertNull(user.getApps());
-        assertEquals(sub, user.getSub());
         assertEquals(sub, user.getUserId());
     }
 


### PR DESCRIPTION
- added an optional flag to generate both public and private API Keys 
- added client credentials grant for public and private keys

also:
- removed openid half compliant routes/bodys in favor of simple pure oauth2
- moved from audiences to scopes (set in properties)
- added scp claim to jwt

fixes #24
fixes #23 