### PR TITLE
Feat: Add Orgs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: OpenApi
-        uses: readmeio/rdme@8.5.0
+        uses: readmeio/rdme@8.6.1
         with:
           rdme: openapi openapi.yaml --key=${{ secrets.README_API_KEY }} --id=63c6011fa9d9d30086fb6427
 

--- a/database/create_tables.sql
+++ b/database/create_tables.sql
@@ -22,6 +22,16 @@ CREATE TABLE IF NOT EXISTS refresh(
     expires_utc TIMESTAMP WITH TIME ZONE NOT NULL
 );
 
+-- -----------------------------------------------------------------------
+-- ORG INFO
+-- -----------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS org_info(
+    org_info_id BIGSERIAL PRIMARY KEY,
+    org_id UUID NOT NULL UNIQUE,
+    billing_id TEXT NOT NULL,
+    created_utc TIMESTAMP WITH TIME ZONE NOT NULL,
+    modified_utc TIMESTAMP WITH TIME ZONE NOT NULL
+);
 
 -- -----------------------------------------------------------------------
 -- APP INFO
@@ -30,10 +40,10 @@ CREATE TABLE IF NOT EXISTS app_info(
     app_info_id BIGSERIAL PRIMARY KEY,
     app_id UUID NOT NULL UNIQUE,
     app_name TEXT NOT NULL,
+    org_info_id BIGINT REFERENCES org_info(org_info_id) NOT NULL,
     created_utc TIMESTAMP WITH TIME ZONE NOT NULL,
     modified_utc TIMESTAMP WITH TIME ZONE NOT NULL
 );
-
 
 -- -----------------------------------------------------------------------
 -- USER INFO
@@ -41,20 +51,10 @@ CREATE TABLE IF NOT EXISTS app_info(
 CREATE TABLE IF NOT EXISTS user_info(
     user_info_id BIGSERIAL PRIMARY KEY,
     user_id UUID NOT NULL UNIQUE,
+    org_info_id BIGINT REFERENCES org_info(org_info_id) NOT NULL,
     email TEXT NOT NULL UNIQUE,
     created_utc TIMESTAMP WITH TIME ZONE NOT NULL,
     modified_utc TIMESTAMP WITH TIME ZONE NOT NULL
-);
-
--- -----------------------------------------------------------------------
--- APP_USER JOIN TABLE
--- -----------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS app_user(
-    app_user_id BIGSERIAL PRIMARY KEY,
-    app_info_id BIGINT REFERENCES app_info(app_info_id) NOT NULL,
-    user_info_id BIGINT REFERENCES user_info(user_info_id) NOT NULL,
-    created_utc TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-    UNIQUE(app_info_id, user_info_id)
 );
 
 -- -----------------------------------------------------------------------

--- a/database/create_tables.sql
+++ b/database/create_tables.sql
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS refresh(
 CREATE TABLE IF NOT EXISTS org_info(
     org_info_id BIGSERIAL PRIMARY KEY,
     org_id UUID NOT NULL UNIQUE,
-    billing_id TEXT NOT NULL,
+    billing_id TEXT,
     created_utc TIMESTAMP WITH TIME ZONE NOT NULL,
     modified_utc TIMESTAMP WITH TIME ZONE NOT NULL
 );

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
-            <version>2.0.4</version>
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>io.sentry</groupId>
             <artifactId>sentry-logback</artifactId>
-            <version>6.16.0</version>
+            <version>6.17.0</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>io.sentry</groupId>
             <artifactId>sentry-spring-boot-starter</artifactId>
-            <version>6.16.0</version>
+            <version>6.17.0</version>
         </dependency>
         <dependency>
             <groupId>io.sentry</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-common</artifactId>
-            <version>2.0.4</version>
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.openapitools</groupId>

--- a/src/main/java/com/mytiki/l0_auth/features/latest/FeaturesConfig.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/FeaturesConfig.java
@@ -7,6 +7,7 @@ package com.mytiki.l0_auth.features.latest;
 
 import com.mytiki.l0_auth.features.latest.api_key.ApiKeyConfig;
 import com.mytiki.l0_auth.features.latest.app_info.AppInfoConfig;
+import com.mytiki.l0_auth.features.latest.org_info.OrgInfoConfig;
 import com.mytiki.l0_auth.features.latest.otp.OtpConfig;
 import com.mytiki.l0_auth.features.latest.refresh.RefreshConfig;
 import com.mytiki.l0_auth.features.latest.user_info.UserInfoConfig;
@@ -17,7 +18,8 @@ import org.springframework.context.annotation.Import;
         RefreshConfig.class,
         UserInfoConfig.class,
         AppInfoConfig.class,
-        ApiKeyConfig.class
+        ApiKeyConfig.class,
+        OrgInfoConfig.class
 })
 public class FeaturesConfig {
 }

--- a/src/main/java/com/mytiki/l0_auth/features/latest/app_info/AppInfoController.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/app_info/AppInfoController.java
@@ -7,11 +7,9 @@ package com.mytiki.l0_auth.features.latest.app_info;
 
 import com.mytiki.l0_auth.utilities.Constants;
 import com.mytiki.spring_rest_api.ApiConstants;
-import com.mytiki.spring_rest_api.ApiExceptionBuilder;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
@@ -35,11 +33,7 @@ public class AppInfoController {
             security = @SecurityRequirement(name = "oauth", scopes = "auth"))
     @RequestMapping(method = RequestMethod.GET, path = "/{appId}")
     public AppInfoAO get(Principal principal, @PathVariable String appId) {
-        AppInfoAO rsp = service.get(appId);
-        if(rsp.getUsers().contains(principal.getName()))
-            return rsp;
-        else
-            throw new ApiExceptionBuilder(HttpStatus.FORBIDDEN).build();
+        return service.get(principal.getName(), appId);
     }
 
     @Operation(operationId = Constants.PROJECT_DASH_PATH +  "-app-create",

--- a/src/main/java/com/mytiki/l0_auth/features/latest/app_info/AppInfoDO.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/app_info/AppInfoDO.java
@@ -5,12 +5,11 @@
 
 package com.mytiki.l0_auth.features.latest.app_info;
 
-import com.mytiki.l0_auth.features.latest.user_info.UserInfoDO;
+import com.mytiki.l0_auth.features.latest.org_info.OrgInfoDO;
 import jakarta.persistence.*;
 
 import java.io.Serializable;
 import java.time.ZonedDateTime;
-import java.util.Set;
 import java.util.UUID;
 
 @Entity
@@ -19,7 +18,7 @@ public class AppInfoDO implements Serializable {
     private Long id;
     private UUID appId;
     private String name;
-    private Set<UserInfoDO> users;
+    private OrgInfoDO org;
     private ZonedDateTime created;
     private ZonedDateTime modified;
 
@@ -51,17 +50,14 @@ public class AppInfoDO implements Serializable {
         this.name = name;
     }
 
-    @ManyToMany(fetch = FetchType.EAGER)
-    @JoinTable(
-            name = "app_user",
-            joinColumns = @JoinColumn(name = "app_info_id"),
-            inverseJoinColumns = @JoinColumn(name = "user_info_id"))
-    public Set<UserInfoDO> getUsers() {
-        return users;
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "org_info_id")
+    public OrgInfoDO getOrg() {
+        return org;
     }
 
-    public void setUsers(Set<UserInfoDO> users) {
-        this.users = users;
+    public void setOrg(OrgInfoDO org) {
+        this.org = org;
     }
 
     @Column(name = "created_utc")

--- a/src/main/java/com/mytiki/l0_auth/features/latest/app_info/AppInfoService.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/app_info/AppInfoService.java
@@ -26,7 +26,6 @@ public class AppInfoService {
         this.userInfoService = userInfoService;
     }
 
-    @Transactional
     public AppInfoAO create(String name, String userId){
        Optional<UserInfoDO> user =  userInfoService.getDO(userId);
        if(user.isEmpty())
@@ -61,7 +60,6 @@ public class AppInfoService {
         }
     }
 
-    @Transactional
     public AppInfoAO update(String userId, String appId, AppInfoAOReq req){
         Optional<UserInfoDO> user =  userInfoService.getDO(userId);
         if(user.isEmpty())

--- a/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoAO.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoAO.java
@@ -3,31 +3,18 @@
  * MIT license. See LICENSE file in root directory.
  */
 
-package com.mytiki.l0_auth.features.latest.app_info;
+package com.mytiki.l0_auth.features.latest.org_info;
 
 import java.time.ZonedDateTime;
+import java.util.Set;
 
-public class AppInfoAO {
-    private String appId;
-    private String name;
+public class OrgInfoAO {
     private String orgId;
+    private String billingId;
+    private Set<String> users;
+    private Set<String> apps;
     private ZonedDateTime modified;
     private ZonedDateTime created;
-
-    public String getAppId() {
-        return appId;
-    }
-    public void setAppId(String appId) {
-        this.appId = appId;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
 
     public String getOrgId() {
         return orgId;
@@ -37,12 +24,36 @@ public class AppInfoAO {
         this.orgId = orgId;
     }
 
+    public String getBillingId() {
+        return billingId;
+    }
+
+    public void setBillingId(String billingId) {
+        this.billingId = billingId;
+    }
+
     public ZonedDateTime getModified() {
         return modified;
     }
 
     public void setModified(ZonedDateTime modified) {
         this.modified = modified;
+    }
+
+    public Set<String> getUsers() {
+        return users;
+    }
+
+    public void setUsers(Set<String> users) {
+        this.users = users;
+    }
+
+    public Set<String> getApps() {
+        return apps;
+    }
+
+    public void setApps(Set<String> apps) {
+        this.apps = apps;
     }
 
     public ZonedDateTime getCreated() {

--- a/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoAOReq.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoAOReq.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_auth.features.latest.org_info;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class OrgInfoAOReq {
+    private String email;
+
+    @JsonCreator
+    public OrgInfoAOReq(@JsonProperty(required = true) String email) {
+        this.email = email;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoConfig.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoConfig.java
@@ -18,13 +18,13 @@ public class OrgInfoConfig {
     public static final String PACKAGE_PATH = Constants.PACKAGE_FEATURES_LATEST_DOT_PATH + ".org_info";
 
     @Bean
-    public OrgInfoService orgInfoService(@Autowired OrgInfoRepository repository,
-                                         @Autowired UserInfoService userInfoService){
-        return new OrgInfoService(repository, userInfoService);
+    public OrgInfoService orgInfoService(@Autowired OrgInfoRepository repository){
+        return new OrgInfoService(repository);
     }
 
     @Bean
-    public OrgInfoController orgInfoController(@Autowired OrgInfoService service){
-        return new OrgInfoController(service);
+    public OrgInfoController orgInfoController(@Autowired OrgInfoService service,
+                                               @Autowired UserInfoService userInfoService){
+        return new OrgInfoController(service, userInfoService);
     }
 }

--- a/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoConfig.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoConfig.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_auth.features.latest.org_info;
+
+import com.mytiki.l0_auth.features.latest.user_info.UserInfoService;
+import com.mytiki.l0_auth.utilities.Constants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@EnableJpaRepositories(OrgInfoConfig.PACKAGE_PATH)
+@EntityScan(OrgInfoConfig.PACKAGE_PATH)
+public class OrgInfoConfig {
+    public static final String PACKAGE_PATH = Constants.PACKAGE_FEATURES_LATEST_DOT_PATH + ".org_info";
+
+    @Bean
+    public OrgInfoService orgInfoService(@Autowired OrgInfoRepository repository,
+                                         @Autowired UserInfoService userInfoService){
+        return new OrgInfoService(repository, userInfoService);
+    }
+
+    @Bean
+    public OrgInfoController orgInfoController(@Autowired OrgInfoService service){
+        return new OrgInfoController(service);
+    }
+}

--- a/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoController.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoController.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_auth.features.latest.org_info;
+
+import com.mytiki.l0_auth.utilities.Constants;
+import com.mytiki.spring_rest_api.ApiConstants;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+
+@Tag(name = "")
+@RestController
+@RequestMapping(value = OrgInfoController.PATH_CONTROLLER)
+public class OrgInfoController {
+    public static final String PATH_CONTROLLER = ApiConstants.API_LATEST_ROUTE + "org";
+
+    private final OrgInfoService service;
+
+    public OrgInfoController(OrgInfoService service) {
+        this.service = service;
+    }
+
+    @Operation(operationId = Constants.PROJECT_DASH_PATH +  "-org-get",
+            summary = "Get Org",
+            description = "Get an org's profile",
+            security = @SecurityRequirement(name = "oauth", scopes = "auth"))
+    @RequestMapping(method = RequestMethod.GET, path = "/{orgId}")
+    public OrgInfoAO get(Principal principal, @PathVariable String orgId) {
+        return service.get(principal.getName(), orgId);
+    }
+
+    @Operation(operationId = Constants.PROJECT_DASH_PATH +  "-org-get",
+            summary = "Add to Org",
+            description = "Add a user to an org",
+            security = @SecurityRequirement(name = "oauth", scopes = "auth"))
+    @RequestMapping(method = RequestMethod.POST, path = "/{orgId}")
+    @ResponseStatus(code = HttpStatus.NO_CONTENT)
+    public void addToOrg(Principal principal, @PathVariable String orgId, @RequestBody OrgInfoAOReq body) {
+        service.addUser(principal.getName(), orgId, body);
+    }
+
+    //route to update billing.
+}

--- a/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoController.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoController.java
@@ -5,6 +5,7 @@
 
 package com.mytiki.l0_auth.features.latest.org_info;
 
+import com.mytiki.l0_auth.features.latest.user_info.UserInfoService;
 import com.mytiki.l0_auth.utilities.Constants;
 import com.mytiki.spring_rest_api.ApiConstants;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,9 +23,11 @@ public class OrgInfoController {
     public static final String PATH_CONTROLLER = ApiConstants.API_LATEST_ROUTE + "org";
 
     private final OrgInfoService service;
+    private final UserInfoService userInfoService;
 
-    public OrgInfoController(OrgInfoService service) {
+    public OrgInfoController(OrgInfoService service, UserInfoService userInfoService) {
         this.service = service;
+        this.userInfoService = userInfoService;
     }
 
     @Operation(operationId = Constants.PROJECT_DASH_PATH +  "-org-get",
@@ -43,7 +46,7 @@ public class OrgInfoController {
     @RequestMapping(method = RequestMethod.POST, path = "/{orgId}")
     @ResponseStatus(code = HttpStatus.NO_CONTENT)
     public void addToOrg(Principal principal, @PathVariable String orgId, @RequestBody OrgInfoAOReq body) {
-        service.addUser(principal.getName(), orgId, body);
+        userInfoService.addToOrg(principal.getName(), orgId, body.getEmail());
     }
 
     //route to update billing.

--- a/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoDO.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoDO.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_auth.features.latest.org_info;
+
+import com.mytiki.l0_auth.features.latest.app_info.AppInfoDO;
+import com.mytiki.l0_auth.features.latest.user_info.UserInfoDO;
+import jakarta.persistence.*;
+
+import java.io.Serializable;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "org_info")
+public class OrgInfoDO implements Serializable {
+    private Long id;
+    private UUID orgId;
+    private String billingId;
+    private List<UserInfoDO> users;
+    private List<AppInfoDO> apps;
+    private ZonedDateTime created;
+    private ZonedDateTime modified;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "org_info_id")
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Column(name = "org_id")
+    public UUID getOrgId() {
+        return orgId;
+    }
+
+    public void setOrgId(UUID orgId) {
+        this.orgId = orgId;
+    }
+
+    @Column(name = "billing_id")
+    public String getBillingId() {
+        return billingId;
+    }
+
+    public void setBillingId(String billingId) {
+        this.billingId = billingId;
+    }
+
+    @OneToMany(mappedBy = "org")
+    public List<UserInfoDO> getUsers() {
+        return users;
+    }
+
+    public void setUsers(List<UserInfoDO> users) {
+        this.users = users;
+    }
+
+    @OneToMany(mappedBy = "org")
+    public List<AppInfoDO> getApps() {
+        return apps;
+    }
+
+    public void setApps(List<AppInfoDO> apps) {
+        this.apps = apps;
+    }
+
+    @Column(name = "created_utc")
+    public ZonedDateTime getCreated() {
+        return created;
+    }
+
+    public void setCreated(ZonedDateTime created) {
+        this.created = created;
+    }
+
+    @Column(name = "modified_utc")
+    public ZonedDateTime getModified() {
+        return modified;
+    }
+
+    public void setModified(ZonedDateTime modified) {
+        this.modified = modified;
+    }
+}

--- a/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoRepository.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoRepository.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_auth.features.latest.org_info;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface OrgInfoRepository extends JpaRepository<OrgInfoDO, UUID> {
+    Optional<OrgInfoDO> findByOrgId(UUID orgId);
+}

--- a/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoService.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoService.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_auth.features.latest.org_info;
+
+import com.mytiki.l0_auth.features.latest.user_info.UserInfoDO;
+import com.mytiki.l0_auth.features.latest.user_info.UserInfoService;
+import com.mytiki.spring_rest_api.ApiExceptionBuilder;
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class OrgInfoService {
+
+    private final OrgInfoRepository repository;
+    private final UserInfoService userInfoService;
+
+    public OrgInfoService(OrgInfoRepository repository, UserInfoService userInfoService) {
+        this.repository = repository;
+        this.userInfoService = userInfoService;
+    }
+
+    public OrgInfoDO create(){
+        OrgInfoDO org = new OrgInfoDO();
+        ZonedDateTime now = ZonedDateTime.now();
+        org.setOrgId(UUID.randomUUID());
+        org.setCreated(now);
+        org.setModified(now);
+        return repository.save(org);
+    }
+
+    public void addUser(String userId, String orgId, OrgInfoAOReq req){
+        Optional<UserInfoDO> user = userInfoService.getDO(userId);
+        if(user.isEmpty() || !user.get().getOrg().getOrgId().toString().equals(orgId))
+            throw new ApiExceptionBuilder(HttpStatus.FORBIDDEN).build();
+        userInfoService.addToOrg(req.getEmail(), user.get().getOrg());
+    }
+
+    @Transactional
+    public OrgInfoAO get(String userId, String orgId){
+        Optional<OrgInfoDO> found = repository.findByOrgId(UUID.fromString(orgId));
+        if(found.isPresent()){
+            List<String> allowedUserIds = found.get().getUsers()
+                    .stream()
+                    .map(user -> user.getUserId().toString())
+                    .toList();
+            if(!allowedUserIds.contains(userId))
+                throw new ApiExceptionBuilder(HttpStatus.FORBIDDEN).build();
+            return toAO(found.get());
+        }else{
+            OrgInfoAO rsp = new OrgInfoAO();
+            rsp.setOrgId(orgId);
+            return rsp;
+        }
+    }
+
+//    public OrgInfoDO setBilling(String orgId, String billingId){
+//
+//    }
+
+    private OrgInfoAO toAO(OrgInfoDO src){
+        OrgInfoAO rsp = new OrgInfoAO();
+        rsp.setOrgId(src.getOrgId().toString());
+        rsp.setBillingId(src.getBillingId());
+
+        if(src.getUsers() != null) {
+            rsp.setUsers(src.getUsers()
+                    .stream()
+                    .map(user -> user.getUserId().toString())
+                    .collect(Collectors.toSet()));
+        }
+
+        if(src.getApps() != null) {
+            rsp.setApps(src.getApps()
+                    .stream()
+                    .map(app -> app.getAppId().toString())
+                    .collect(Collectors.toSet()));
+        }
+
+        rsp.setModified(src.getModified());
+        rsp.setCreated(src.getCreated());
+        return rsp;
+    }
+}

--- a/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoService.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoService.java
@@ -5,8 +5,6 @@
 
 package com.mytiki.l0_auth.features.latest.org_info;
 
-import com.mytiki.l0_auth.features.latest.user_info.UserInfoDO;
-import com.mytiki.l0_auth.features.latest.user_info.UserInfoService;
 import com.mytiki.spring_rest_api.ApiExceptionBuilder;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,11 +18,9 @@ import java.util.stream.Collectors;
 public class OrgInfoService {
 
     private final OrgInfoRepository repository;
-    private final UserInfoService userInfoService;
 
-    public OrgInfoService(OrgInfoRepository repository, UserInfoService userInfoService) {
+    public OrgInfoService(OrgInfoRepository repository) {
         this.repository = repository;
-        this.userInfoService = userInfoService;
     }
 
     public OrgInfoDO create(){
@@ -34,13 +30,6 @@ public class OrgInfoService {
         org.setCreated(now);
         org.setModified(now);
         return repository.save(org);
-    }
-
-    public void addUser(String userId, String orgId, OrgInfoAOReq req){
-        Optional<UserInfoDO> user = userInfoService.getDO(userId);
-        if(user.isEmpty() || !user.get().getOrg().getOrgId().toString().equals(orgId))
-            throw new ApiExceptionBuilder(HttpStatus.FORBIDDEN).build();
-        userInfoService.addToOrg(req.getEmail(), user.get().getOrg());
     }
 
     @Transactional

--- a/src/main/java/com/mytiki/l0_auth/features/latest/user_info/UserInfoAO.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/user_info/UserInfoAO.java
@@ -6,14 +6,13 @@
 package com.mytiki.l0_auth.features.latest.user_info;
 
 import java.time.ZonedDateTime;
-import java.util.Set;
 
 public class UserInfoAO {
     private String userId;
     private String email;
+    private String orgId;
     private ZonedDateTime modified;
     private ZonedDateTime created;
-    private Set<String> apps;
 
     public String getUserId() {
         return userId;
@@ -31,6 +30,14 @@ public class UserInfoAO {
         this.email = email;
     }
 
+    public String getOrgId() {
+        return orgId;
+    }
+
+    public void setOrgId(String orgId) {
+        this.orgId = orgId;
+    }
+
     public ZonedDateTime getModified() {
         return modified;
     }
@@ -45,13 +52,5 @@ public class UserInfoAO {
 
     public void setCreated(ZonedDateTime created) {
         this.created = created;
-    }
-
-    public Set<String> getApps() {
-        return apps;
-    }
-
-    public void setApps(Set<String> apps) {
-        this.apps = apps;
     }
 }

--- a/src/main/java/com/mytiki/l0_auth/features/latest/user_info/UserInfoConfig.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/user_info/UserInfoConfig.java
@@ -5,6 +5,7 @@
 
 package com.mytiki.l0_auth.features.latest.user_info;
 
+import com.mytiki.l0_auth.features.latest.org_info.OrgInfoService;
 import com.mytiki.l0_auth.utilities.Constants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -22,7 +23,8 @@ public class UserInfoConfig {
     }
 
     @Bean
-    public UserInfoService userInfoService(@Autowired UserInfoRepository repository){
-        return new UserInfoService(repository);
+    public UserInfoService userInfoService(@Autowired UserInfoRepository repository,
+                                           @Autowired OrgInfoService orgInfoService){
+        return new UserInfoService(repository, orgInfoService);
     }
 }

--- a/src/main/java/com/mytiki/l0_auth/features/latest/user_info/UserInfoDO.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/user_info/UserInfoDO.java
@@ -5,12 +5,11 @@
 
 package com.mytiki.l0_auth.features.latest.user_info;
 
-import com.mytiki.l0_auth.features.latest.app_info.AppInfoDO;
+import com.mytiki.l0_auth.features.latest.org_info.OrgInfoDO;
 import jakarta.persistence.*;
 
 import java.io.Serializable;
 import java.time.ZonedDateTime;
-import java.util.Set;
 import java.util.UUID;
 
 @Entity
@@ -19,7 +18,7 @@ public class UserInfoDO implements Serializable {
     private Long id;
     private UUID userId;
     private String email;
-    private Set<AppInfoDO> apps;
+    private OrgInfoDO org;
     private ZonedDateTime created;
     private ZonedDateTime modified;
 
@@ -52,13 +51,14 @@ public class UserInfoDO implements Serializable {
         this.email = email;
     }
 
-    @ManyToMany(mappedBy = "users", fetch = FetchType.EAGER)
-    public Set<AppInfoDO> getApps() {
-        return apps;
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "org_info_id")
+    public OrgInfoDO getOrg() {
+        return org;
     }
 
-    public void setApps(Set<AppInfoDO> apps) {
-        this.apps = apps;
+    public void setOrg(OrgInfoDO org) {
+        this.org = org;
     }
 
     @Column(name = "created_utc")

--- a/src/main/java/com/mytiki/l0_auth/features/latest/user_info/UserInfoService.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/user_info/UserInfoService.java
@@ -5,20 +5,23 @@
 
 package com.mytiki.l0_auth.features.latest.user_info;
 
+import com.mytiki.l0_auth.features.latest.org_info.OrgInfoDO;
+import com.mytiki.l0_auth.features.latest.org_info.OrgInfoService;
 import com.mytiki.spring_rest_api.ApiExceptionBuilder;
 import org.springframework.http.HttpStatus;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 public class UserInfoService {
 
     private final UserInfoRepository repository;
+    private final OrgInfoService orgInfoService;
 
-    public UserInfoService(UserInfoRepository repository) {
+    public UserInfoService(UserInfoRepository repository, OrgInfoService orgInfoService) {
         this.repository = repository;
+        this.orgInfoService = orgInfoService;
     }
 
     public UserInfoAO get(String userId){
@@ -34,6 +37,21 @@ public class UserInfoService {
         return repository.findByUserId(UUID.fromString(userId));
     }
 
+    public UserInfoDO addToOrg(String email, OrgInfoDO org){
+        Optional<UserInfoDO> found = repository.findByEmail(email);
+        if(found.isEmpty()) {
+            throw new ApiExceptionBuilder(HttpStatus.BAD_REQUEST)
+                    .message("User does not exist")
+                    .properties("email", email)
+                    .build();
+        }else {
+            UserInfoDO updated = found.get();
+            updated.setOrg(org);
+            updated.setModified(ZonedDateTime.now());
+            return repository.save(updated);
+        }
+    }
+
     public UserInfoAO createIfNotExists(String email) {
         Optional<UserInfoDO> found = repository.findByEmail(email);
         UserInfoDO userInfo;
@@ -41,6 +59,7 @@ public class UserInfoService {
             UserInfoDO newUser = new UserInfoDO();
             newUser.setUserId(UUID.randomUUID());
             newUser.setEmail(email);
+            newUser.setOrg(orgInfoService.create());
             ZonedDateTime now = ZonedDateTime.now();
             newUser.setCreated(now);
             newUser.setModified(now);
@@ -71,8 +90,7 @@ public class UserInfoService {
         rsp.setEmail(src.getEmail());
         rsp.setCreated(src.getCreated());
         rsp.setModified(src.getModified());
-        if(src.getApps() != null)
-            rsp.setApps(src.getApps().stream().map(a -> a.getAppId().toString()).collect(Collectors.toSet()));
+        rsp.setOrgId(src.getOrg().getOrgId().toString());
         return rsp;
     }
 }

--- a/src/main/java/com/mytiki/l0_auth/features/latest/user_info/UserInfoService.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/user_info/UserInfoService.java
@@ -5,7 +5,6 @@
 
 package com.mytiki.l0_auth.features.latest.user_info;
 
-import com.mytiki.l0_auth.features.latest.org_info.OrgInfoDO;
 import com.mytiki.l0_auth.features.latest.org_info.OrgInfoService;
 import com.mytiki.spring_rest_api.ApiExceptionBuilder;
 import org.springframework.http.HttpStatus;
@@ -37,16 +36,20 @@ public class UserInfoService {
         return repository.findByUserId(UUID.fromString(userId));
     }
 
-    public UserInfoDO addToOrg(String email, OrgInfoDO org){
-        Optional<UserInfoDO> found = repository.findByEmail(email);
+    public UserInfoDO addToOrg(String userId, String orgId, String emailToAdd){
+        Optional<UserInfoDO> user = getDO(userId);
+        if(user.isEmpty() || !user.get().getOrg().getOrgId().toString().equals(orgId))
+            throw new ApiExceptionBuilder(HttpStatus.FORBIDDEN).build();
+
+        Optional<UserInfoDO> found = repository.findByEmail(emailToAdd);
         if(found.isEmpty()) {
             throw new ApiExceptionBuilder(HttpStatus.BAD_REQUEST)
                     .message("User does not exist")
-                    .properties("email", email)
+                    .properties("email", emailToAdd)
                     .build();
         }else {
             UserInfoDO updated = found.get();
-            updated.setOrg(org);
+            updated.setOrg(user.get().getOrg());
             updated.setModified(ZonedDateTime.now());
             return repository.save(updated);
         }

--- a/src/test/java/com/mytiki/l0_auth/ApiKeyTest.java
+++ b/src/test/java/com/mytiki/l0_auth/ApiKeyTest.java
@@ -8,6 +8,7 @@ package com.mytiki.l0_auth;
 import com.mytiki.l0_auth.features.latest.api_key.*;
 import com.mytiki.l0_auth.features.latest.app_info.AppInfoAO;
 import com.mytiki.l0_auth.features.latest.app_info.AppInfoService;
+import com.mytiki.l0_auth.features.latest.org_info.OrgInfoService;
 import com.mytiki.l0_auth.features.latest.user_info.UserInfoDO;
 import com.mytiki.l0_auth.features.latest.user_info.UserInfoRepository;
 import com.mytiki.l0_auth.main.App;
@@ -58,6 +59,9 @@ public class ApiKeyTest {
     @Autowired
     private JwtDecoder jwtDecoder;
 
+    @Autowired
+    private OrgInfoService orgInfoService;
+
     @Test
     public void Test_Create_Success() {
         UserInfoDO testUser = new UserInfoDO();
@@ -65,6 +69,7 @@ public class ApiKeyTest {
         testUser.setUserId(UUID.randomUUID());
         testUser.setCreated(ZonedDateTime.now());
         testUser.setModified(ZonedDateTime.now());
+        testUser.setOrg(orgInfoService.create());
         testUser = userInfoRepository.save(testUser);
         AppInfoAO app = appInfoService.create("testApp", testUser.getUserId().toString());
 
@@ -82,6 +87,7 @@ public class ApiKeyTest {
         testUser.setUserId(userId);
         testUser.setCreated(ZonedDateTime.now());
         testUser.setModified(ZonedDateTime.now());
+        testUser.setOrg(orgInfoService.create());
         userInfoRepository.save(testUser);
 
         ApiException ex = assertThrows(ApiException.class,
@@ -96,6 +102,7 @@ public class ApiKeyTest {
         testUser.setUserId(UUID.randomUUID());
         testUser.setCreated(ZonedDateTime.now());
         testUser.setModified(ZonedDateTime.now());
+        testUser.setOrg(orgInfoService.create());
         testUser = userInfoRepository.save(testUser);
         AppInfoAO app = appInfoService.create("testApp", testUser.getUserId().toString());
 
@@ -115,6 +122,7 @@ public class ApiKeyTest {
         testUser.setUserId(userId);
         testUser.setCreated(ZonedDateTime.now());
         testUser.setModified(ZonedDateTime.now());
+        testUser.setOrg(orgInfoService.create());
         testUser = userInfoRepository.save(testUser);
         AppInfoAO app = appInfoService.create("testApp", testUser.getUserId().toString());
         service.create(testUser.getUserId().toString(), app.getAppId(), true);
@@ -131,6 +139,7 @@ public class ApiKeyTest {
         testUser.setUserId(UUID.randomUUID());
         testUser.setCreated(ZonedDateTime.now());
         testUser.setModified(ZonedDateTime.now());
+        testUser.setOrg(orgInfoService.create());
         testUser = userInfoRepository.save(testUser);
         AppInfoAO app = appInfoService.create("testApp", testUser.getUserId().toString());
 
@@ -148,6 +157,7 @@ public class ApiKeyTest {
         testUser.setUserId(UUID.randomUUID());
         testUser.setCreated(ZonedDateTime.now());
         testUser.setModified(ZonedDateTime.now());
+        testUser.setOrg(orgInfoService.create());
         testUser = userInfoRepository.save(testUser);
         AppInfoAO app = appInfoService.create("testApp", testUser.getUserId().toString());
 
@@ -169,6 +179,7 @@ public class ApiKeyTest {
         testUser.setUserId(UUID.randomUUID());
         testUser.setCreated(ZonedDateTime.now());
         testUser.setModified(ZonedDateTime.now());
+        testUser.setOrg(orgInfoService.create());
         testUser = userInfoRepository.save(testUser);
         AppInfoAO app = appInfoService.create("testApp", testUser.getUserId().toString());
 
@@ -191,6 +202,7 @@ public class ApiKeyTest {
         testUser.setUserId(UUID.randomUUID());
         testUser.setCreated(ZonedDateTime.now());
         testUser.setModified(ZonedDateTime.now());
+        testUser.setOrg(orgInfoService.create());
         testUser = userInfoRepository.save(testUser);
         AppInfoAO app = appInfoService.create("testApp", testUser.getUserId().toString());
         ApiKeyAOCreate created = service.create(testUser.getUserId().toString(), app.getAppId(), true);
@@ -210,6 +222,7 @@ public class ApiKeyTest {
         testUser.setUserId(UUID.randomUUID());
         testUser.setCreated(ZonedDateTime.now());
         testUser.setModified(ZonedDateTime.now());
+        testUser.setOrg(orgInfoService.create());
         testUser = userInfoRepository.save(testUser);
         AppInfoAO app = appInfoService.create("testApp", testUser.getUserId().toString());
         ApiKeyAOCreate created = service.create(testUser.getUserId().toString(), app.getAppId(), false);
@@ -227,6 +240,7 @@ public class ApiKeyTest {
         testUser.setUserId(UUID.randomUUID());
         testUser.setCreated(ZonedDateTime.now());
         testUser.setModified(ZonedDateTime.now());
+        testUser.setOrg(orgInfoService.create());
         testUser = userInfoRepository.save(testUser);
         AppInfoAO app = appInfoService.create("testApp", testUser.getUserId().toString());
         ApiKeyAOCreate created = service.create(testUser.getUserId().toString(), app.getAppId(), true);
@@ -246,6 +260,7 @@ public class ApiKeyTest {
         testUser.setUserId(UUID.randomUUID());
         testUser.setCreated(ZonedDateTime.now());
         testUser.setModified(ZonedDateTime.now());
+        testUser.setOrg(orgInfoService.create());
         testUser = userInfoRepository.save(testUser);
         AppInfoAO app = appInfoService.create("testApp", testUser.getUserId().toString());
         ApiKeyAOCreate created = service.create(testUser.getUserId().toString(), app.getAppId(), false);
@@ -262,6 +277,7 @@ public class ApiKeyTest {
         testUser.setUserId(UUID.randomUUID());
         testUser.setCreated(ZonedDateTime.now());
         testUser.setModified(ZonedDateTime.now());
+        testUser.setOrg(orgInfoService.create());
         testUser = userInfoRepository.save(testUser);
         AppInfoAO app = appInfoService.create("testApp", testUser.getUserId().toString());
         ApiKeyAOCreate created = service.create(testUser.getUserId().toString(), app.getAppId(), false);

--- a/src/test/java/com/mytiki/l0_auth/AppInfoTest.java
+++ b/src/test/java/com/mytiki/l0_auth/AppInfoTest.java
@@ -8,6 +8,7 @@ package com.mytiki.l0_auth;
 import com.mytiki.l0_auth.features.latest.app_info.AppInfoAO;
 import com.mytiki.l0_auth.features.latest.app_info.AppInfoRepository;
 import com.mytiki.l0_auth.features.latest.app_info.AppInfoService;
+import com.mytiki.l0_auth.features.latest.org_info.OrgInfoService;
 import com.mytiki.l0_auth.features.latest.user_info.UserInfoDO;
 import com.mytiki.l0_auth.features.latest.user_info.UserInfoRepository;
 import com.mytiki.l0_auth.main.App;
@@ -44,6 +45,9 @@ public class AppInfoTest {
     @Autowired
     private AppInfoService service;
 
+    @Autowired
+    private OrgInfoService orgInfoService;
+
     @Test
     public void Test_Create_Success() {
         String name = "testApp";
@@ -53,6 +57,7 @@ public class AppInfoTest {
         testUser.setUserId(UUID.randomUUID());
         testUser.setCreated(ZonedDateTime.now());
         testUser.setModified(ZonedDateTime.now());
+        testUser.setOrg(orgInfoService.create());
         testUser = userInfoRepository.save(testUser);
 
         AppInfoAO app = service.create(name, testUser.getUserId().toString());
@@ -60,8 +65,7 @@ public class AppInfoTest {
         assertNotNull(app.getAppId());
         assertNotNull(app.getModified());
         assertNotNull(app.getCreated());
-        assertEquals(1, app.getUsers().size());
-        assertTrue(app.getUsers().contains(testUser.getUserId().toString()));
+        assertEquals(app.getOrgId(), testUser.getOrg().getOrgId().toString());
     }
 
     @Test
@@ -89,28 +93,28 @@ public class AppInfoTest {
         testUser.setUserId(UUID.randomUUID());
         testUser.setCreated(ZonedDateTime.now());
         testUser.setModified(ZonedDateTime.now());
+        testUser.setOrg(orgInfoService.create());
         testUser = userInfoRepository.save(testUser);
 
         AppInfoAO app = service.create(name, testUser.getUserId().toString());
-        AppInfoAO found = service.get(app.getAppId());
+        AppInfoAO found = service.get(testUser.getUserId().toString(), app.getAppId());
 
         assertEquals(app.getAppId(), found.getAppId());
         assertEquals(app.getName(), found.getName());
         assertEquals(app.getModified().withNano(0), found.getModified().withNano(0));
         assertEquals(app.getCreated().withNano(0), found.getCreated().withNano(0));
-        assertEquals(app.getUsers().size(), found.getUsers().size());
-        assertEquals(app.getUsers().stream().findFirst(), found.getUsers().stream().findFirst());
+        assertEquals(app.getOrgId(), found.getOrgId());
     }
 
     @Test
     public void Test_Get_NoApp_Success() {
         String appId = UUID.randomUUID().toString();
-        AppInfoAO found = service.get(appId);
+        AppInfoAO found = service.get(UUID.randomUUID().toString(), appId);
 
         assertEquals(appId, found.getAppId());
         assertNull(found.getName());
         assertNull(found.getModified());
         assertNull(found.getCreated());
-        assertNull(found.getUsers());
+        assertNull(found.getOrgId());
     }
 }

--- a/src/test/java/com/mytiki/l0_auth/OrgInfoTest.java
+++ b/src/test/java/com/mytiki/l0_auth/OrgInfoTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_auth;
+
+import com.mytiki.l0_auth.features.latest.org_info.OrgInfoAO;
+import com.mytiki.l0_auth.features.latest.org_info.OrgInfoDO;
+import com.mytiki.l0_auth.features.latest.org_info.OrgInfoRepository;
+import com.mytiki.l0_auth.features.latest.org_info.OrgInfoService;
+import com.mytiki.l0_auth.features.latest.user_info.UserInfoAO;
+import com.mytiki.l0_auth.features.latest.user_info.UserInfoService;
+import com.mytiki.l0_auth.main.App;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = {App.class}
+)
+@ActiveProfiles(profiles = {"ci", "dev", "local"})
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class OrgInfoTest {
+
+    @Autowired
+    private OrgInfoService service;
+
+    @Autowired
+    private OrgInfoRepository repository;
+
+    @Autowired
+    private UserInfoService userInfoService;
+
+    @Test
+    public void Test_Create_Success() {
+        OrgInfoDO created = service.create();
+
+        assertNull(created.getBillingId());
+        assertNotNull(created.getModified());
+        assertNotNull(created.getCreated());
+        assertNotNull(created.getOrgId());
+        assertNotNull(created.getId());
+    }
+
+    @Test
+    public void Test_Get_Success() {
+        UserInfoAO user = userInfoService.createIfNotExists(UUID.randomUUID() + "@test.com");
+        OrgInfoAO org = service.get(user.getUserId(), user.getOrgId());
+
+        assertTrue(org.getUsers().contains(user.getUserId()));
+        assertEquals(user.getOrgId(), org.getOrgId());
+        assertNull(org.getBillingId());
+        assertNotNull(org.getModified());
+        assertNotNull(org.getCreated());
+    }
+
+    @Test
+    public void Test_Get_None_Success() {
+        String orgId = UUID.randomUUID().toString();
+        OrgInfoAO org = service.get(UUID.randomUUID().toString(), orgId);
+
+        assertEquals(orgId, org.getOrgId());
+        assertNull(org.getApps());
+        assertNull(org.getUsers());
+        assertNull(org.getBillingId());
+        assertNull(org.getCreated());
+        assertNull(org.getModified());
+    }
+}

--- a/src/test/java/com/mytiki/l0_auth/UserInfoTest.java
+++ b/src/test/java/com/mytiki/l0_auth/UserInfoTest.java
@@ -5,6 +5,7 @@
 
 package com.mytiki.l0_auth;
 
+import com.mytiki.l0_auth.features.latest.org_info.OrgInfoService;
 import com.mytiki.l0_auth.features.latest.user_info.*;
 import com.mytiki.l0_auth.main.App;
 import org.junit.jupiter.api.MethodOrderer;
@@ -35,6 +36,9 @@ public class UserInfoTest {
     @Autowired
     private UserInfoService service;
 
+    @Autowired
+    private OrgInfoService orgInfoService;
+
     @Test
     public void Test_Get_Success() {
         UserInfoDO saved = new UserInfoDO();
@@ -42,13 +46,14 @@ public class UserInfoTest {
         saved.setUserId(UUID.randomUUID());
         saved.setCreated(ZonedDateTime.now());
         saved.setModified(ZonedDateTime.now());
+        saved.setOrg(orgInfoService.create());
         saved = repository.save(saved);
 
         UserInfoAO user = service.get(saved.getUserId().toString());
         assertEquals(saved.getEmail(), user.getEmail());
         assertEquals(saved.getModified().withNano(0), user.getModified().withNano(0));
         assertEquals(saved.getCreated().withNano(0), user.getCreated().withNano(0));
-        assertEquals(0, user.getApps().size());
+        assertNotNull(user.getOrgId());
         assertEquals(saved.getUserId().toString(), user.getUserId());
     }
 
@@ -59,7 +64,7 @@ public class UserInfoTest {
         assertNull(user.getEmail());
         assertNull(user.getModified());
         assertNull(user.getCreated());
-        assertNull(user.getApps());
+        assertNull(user.getOrgId());
         assertEquals(sub, user.getUserId());
     }
 
@@ -70,6 +75,7 @@ public class UserInfoTest {
         saved.setUserId(UUID.randomUUID());
         saved.setCreated(ZonedDateTime.now());
         saved.setModified(ZonedDateTime.now());
+        saved.setOrg(orgInfoService.create());
         saved = repository.save(saved);
 
         UserInfoAOUpdate update = new UserInfoAOUpdate();


### PR DESCRIPTION
closes: #78 

Adds `OrgInfo` slice with corresponding integration tests

Updates data model to place ownership of users & apps under orgs