### PR TITLE
feat: add support for internal client creds

### DIFF
--- a/src/main/java/com/mytiki/l0_auth/features/latest/api_key/ApiKeyConfig.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/api_key/ApiKeyConfig.java
@@ -8,6 +8,7 @@ package com.mytiki.l0_auth.features.latest.api_key;
 import com.mytiki.l0_auth.features.latest.app_info.AppInfoService;
 import com.mytiki.l0_auth.features.latest.refresh.RefreshService;
 import com.mytiki.l0_auth.features.latest.user_info.UserInfoService;
+import com.mytiki.l0_auth.security.OauthInternal;
 import com.mytiki.l0_auth.security.OauthScopes;
 import com.mytiki.l0_auth.utilities.Constants;
 import com.nimbusds.jose.JWSSigner;
@@ -37,8 +38,9 @@ public class ApiKeyConfig {
             @Autowired RefreshService refreshService,
             @Autowired JWSSigner signer,
             @Autowired OauthScopes allowedScopes,
-            @Value("${com.mytiki.l0_auth.oauth.client_credentials.public_scopes}") List<String> publicScopes){
+            @Value("${com.mytiki.l0_auth.oauth.client_credentials.public.scopes}") List<String> publicScopes,
+            @Autowired OauthInternal oauthInternal){
         return new ApiKeyService(repository, userInfoService, appInfoService, refreshService, signer,
-                allowedScopes, publicScopes);
+                allowedScopes, publicScopes, oauthInternal);
     }
 }

--- a/src/main/java/com/mytiki/l0_auth/features/latest/otp/OtpConfig.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/otp/OtpConfig.java
@@ -38,7 +38,7 @@ public class OtpConfig {
             @Autowired RefreshService refreshService,
             @Autowired UserInfoService userInfoService,
             @Autowired OauthScopes allowedScopes,
-            @Value("${com.mytiki.l0_auth.oauth.password.anonymous_scopes}") List<String> anonymousScopes) {
+            @Value("${com.mytiki.l0_auth.oauth.password.anonymous.scopes}") List<String> anonymousScopes) {
         return new OtpService(otpRepository, templates, sendgrid, jwsSigner, refreshService, userInfoService,
                 allowedScopes, anonymousScopes);
     }

--- a/src/main/java/com/mytiki/l0_auth/security/OauthConfig.java
+++ b/src/main/java/com/mytiki/l0_auth/security/OauthConfig.java
@@ -27,11 +27,15 @@ import java.lang.invoke.MethodHandles;
 import java.util.List;
 
 @Order(value = Integer.MIN_VALUE)
-@Import(OauthScopes.class)
+@Import({
+        OauthScopes.class,
+        OauthInternal.class
+})
 @ControllerAdvice
 public class OauthConfig {
     protected static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private List<OauthScope> scopes;
+    private OauthInternal internalKeys;
 
     @Bean
     public List<OauthScope> getScopes() {

--- a/src/main/java/com/mytiki/l0_auth/security/OauthInternal.java
+++ b/src/main/java/com/mytiki/l0_auth/security/OauthInternal.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) TIKI Inc.
+ * MIT license. See LICENSE file in root directory.
+ */
+
+package com.mytiki.l0_auth.security;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Map;
+
+@Configuration
+@ConfigurationProperties(value = "com.mytiki.l0-auth.oauth.client-credentials.internal")
+public class OauthInternal {
+    private List<String> scopes;
+    private String json;
+
+    public List<String> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(List<String> scopes) {
+        this.scopes = scopes;
+    }
+
+    public String getJson() {
+        return json;
+    }
+
+    public void setJson(String json) {
+        this.json = json;
+    }
+
+    public Map<String, String> getKeys(){
+        ObjectMapper objectMapper = new ObjectMapper();
+        try{
+            TypeReference<Map<String,String>> type = new TypeReference<Map<String,String>>() {};
+            Map<String, String> keys = objectMapper.readValue(this.json, type);
+            return keys;
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/mytiki/l0_auth/security/SecurityConfig.java
+++ b/src/main/java/com/mytiki/l0_auth/security/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -26,15 +27,18 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Import({
         OauthConfig.class,
-        JWTConfig.class
+        JWTConfig.class,
 })
 @EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
 public class SecurityConfig {
     private final AccessDeniedHandler accessDeniedHandler;
     private final AuthenticationEntryPoint authenticationEntryPoint;
     private final JwtDecoder jwtDecoder;
 
-    public SecurityConfig(@Autowired ObjectMapper objectMapper, @Autowired JwtDecoder jwtDecoder) {
+    public SecurityConfig(
+            @Autowired ObjectMapper objectMapper,
+            @Autowired JwtDecoder jwtDecoder) {
         this.accessDeniedHandler = new AccessDeniedHandler(objectMapper);
         this.authenticationEntryPoint = new AuthenticationEntryPoint(objectMapper);
         this.jwtDecoder = jwtDecoder;

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -24,5 +24,8 @@ com.mytiki.l0_auth.sendgrid.apikey=${SENDGRID_API_KEY:''}
 com.mytiki.l0_auth.jwt.private_key=MEECAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQcEJzAlAgEBBCBOfRkEaPbm/5RkT5rxHblmJay/fzqsOgbunyE/dhIWkg==
 com.mytiki.l0_auth.jwt.kid=d62f289e-b03e-47e9-b36b-2fd94d8e414e
 
+#OAuth
+com.mytiki.l0_auth.oauth.client_credentials.internal.json=${L0_AUTH_OAUTH_CLIENT_CREDENTIALS_INTERNAL_JSON:{}}
+
 # Stripe
 com.mytiki.l0_auth.stripe.signing_secret=${L0_AUTH_STRIPE_SIGNING_SECRET}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -17,6 +17,9 @@ com.mytiki.l0_auth.jwt.kid=${L0_AUTH_JWT_KID}
 # Stripe
 com.mytiki.l0_auth.stripe.signing_secret=${L0_AUTH_STRIPE_SIGNING_SECRET}
 
+#OAuth
+com.mytiki.l0_auth.oauth.client_credentials.internal.json=${L0_AUTH_OAUTH_CLIENT_CREDENTIALS_INTERNAL_JSON:{}}
+
 # Sentry
 sentry.dsn=${SENTRY_DSN}
 sentry.environment=prod

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,6 +38,9 @@ com.mytiki.l0_auth.oauth.scopes.auth.aud=auth.l0.mytiki.com
 com.mytiki.l0_auth.oauth.scopes.registry.aud=registry.l0.mytiki.com
 com.mytiki.l0_auth.oauth.scopes.[registry\:admin].aud=registry.l0.mytiki.com
 com.mytiki.l0_auth.oauth.scopes.[registry\:admin].scp=admin
-com.mytiki.l0_auth.oauth.client_credentials.public_scopes=storage,index,registry
+com.mytiki.l0_auth.oauth.scopes.[internal\:org].aud=auth.l0.mytiki.com
+com.mytiki.l0_auth.oauth.scopes.[internal\:org].scp=internal:org
 
-com.mytiki.l0_auth.oauth.password.anonymous_scopes=
+com.mytiki.l0_auth.oauth.client_credentials.public.scopes=storage,index,registry
+com.mytiki.l0_auth.oauth.password.anonymous.scopes=
+com.mytiki.l0_auth.oauth.client_credentials.internal.scopes=internal:org


### PR DESCRIPTION
use internal client creds + internal:<scope> scopes to generate oauth tokens for use in service to service communication.

better security + easier to manage/implement