### PR TITLE
Feat/get org by id

### DIFF
--- a/src/main/java/com/mytiki/l0_auth/features/latest/app_info/AppInfoAO.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/app_info/AppInfoAO.java
@@ -17,6 +17,7 @@ public class AppInfoAO {
     public String getAppId() {
         return appId;
     }
+
     public void setAppId(String appId) {
         this.appId = appId;
     }

--- a/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoController.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
@@ -37,6 +38,12 @@ public class OrgInfoController {
     @RequestMapping(method = RequestMethod.GET, path = "/{orgId}")
     public OrgInfoAO get(Principal principal, @PathVariable String orgId) {
         return service.get(principal.getName(), orgId);
+    }
+
+    @Secured("SCOPE_internal:org")
+    @RequestMapping(method = RequestMethod.GET)
+    public OrgInfoAO getByApp(Principal principal, @RequestParam(value = "app-id") String appId) {
+        return service.getByApp(appId);
     }
 
     @Operation(operationId = Constants.PROJECT_DASH_PATH +  "-org-post-user",

--- a/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoRepository.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoRepository.java
@@ -6,10 +6,13 @@
 package com.mytiki.l0_auth.features.latest.org_info;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 import java.util.UUID;
 
 public interface OrgInfoRepository extends JpaRepository<OrgInfoDO, UUID> {
     Optional<OrgInfoDO> findByOrgId(UUID orgId);
+    @Query("SELECT o FROM OrgInfoDO o INNER JOIN o.apps a WHERE a.appId = :appId")
+    Optional<OrgInfoDO> findByApp(UUID appId);
 }

--- a/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoService.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/org_info/OrgInfoService.java
@@ -49,6 +49,12 @@ public class OrgInfoService {
         }
     }
 
+    @Transactional
+    public OrgInfoAO getByApp(String appId){
+        Optional<OrgInfoDO> found = repository.findByApp(UUID.fromString(appId));
+        return found.map(this::toAO).orElse(null);
+    }
+
     public OrgInfoDO setBilling(String orgId, String billingId){
         Optional<OrgInfoDO> found = repository.findByOrgId(UUID.fromString(orgId));
         if(found.isPresent()){

--- a/src/test/java/com/mytiki/l0_auth/OrgInfoTest.java
+++ b/src/test/java/com/mytiki/l0_auth/OrgInfoTest.java
@@ -5,6 +5,8 @@
 
 package com.mytiki.l0_auth;
 
+import com.mytiki.l0_auth.features.latest.app_info.AppInfoAO;
+import com.mytiki.l0_auth.features.latest.app_info.AppInfoService;
 import com.mytiki.l0_auth.features.latest.org_info.OrgInfoAO;
 import com.mytiki.l0_auth.features.latest.org_info.OrgInfoDO;
 import com.mytiki.l0_auth.features.latest.org_info.OrgInfoRepository;
@@ -42,6 +44,9 @@ public class OrgInfoTest {
     @Autowired
     private UserInfoService userInfoService;
 
+    @Autowired
+    private AppInfoService appInfoService;
+
     @Test
     public void Test_Create_Success() {
         OrgInfoDO created = service.create();
@@ -76,5 +81,18 @@ public class OrgInfoTest {
         assertNull(org.getBillingId());
         assertNull(org.getCreated());
         assertNull(org.getModified());
+    }
+
+    @Test
+    public void Test_GetByApp_Success() {
+        UserInfoAO user = userInfoService.createIfNotExists(UUID.randomUUID() + "@test.com");
+        AppInfoAO app = appInfoService.create(UUID.randomUUID().toString(), user.getUserId());
+        OrgInfoAO org = service.getByApp(app.getAppId());
+
+        assertTrue(org.getUsers().contains(user.getUserId()));
+        assertEquals(user.getOrgId(), org.getOrgId());
+        assertNull(org.getBillingId());
+        assertNotNull(org.getModified());
+        assertNotNull(org.getCreated());
     }
 }


### PR DESCRIPTION
the registry needs to be able to get the org (specifically billing id) using the app id

uses JWTs and internal:org scope to secure the endpoint. 