### PR TITLE
fix: sub = userId

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT
     url: https://github.com/tiki/l0-auth/blob/main/LICENSE
-  version: 2.2.0
+  version: 2.2.1
 servers:
 - url: https://auth.l0.mytiki.com
 paths:

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.mytiki</groupId>
     <artifactId>l0_auth</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <packaging>jar</packaging>
 
     <name>L0 Auth</name>

--- a/src/main/java/com/mytiki/l0_auth/features/latest/exchange/ExchangeService.java
+++ b/src/main/java/com/mytiki/l0_auth/features/latest/exchange/ExchangeService.java
@@ -47,7 +47,7 @@ public class ExchangeService {
             String requestedScope, String clientId, String subjectToken, String subjectTokenType) {
         String email = validate(clientId, subjectToken, subjectTokenType);
         UserInfoAO userInfo = userInfoService.createIfNotExists(email);
-        String subject = userInfo.getEmail();
+        String subject = userInfo.getUserId();
         Map<String, OauthScope> scopes = allowedScopes.parse(requestedScope);
         List<String>[] audAndScp = allowedScopes.getAudAndScp(scopes);
         try {


### PR DESCRIPTION
User admin tokens require the sub to contain the user id, not the email address (which can be modified)